### PR TITLE
Manpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 
 # Man pages
 /backupctl.?
+/backupctl.?.gz
+/backupctl.ini.?
+/backupctl.ini.?.gz
 
 # Configuration
 /backupctl.ini

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-PROJECT := backupctl
+PROJECT	:= backupctl
+MANPAGES	:= $(PROJECT).8.gz $(PROJECT).ini.5.gz
 
-man: backupctl.8
+man: $(MANPAGES)
 
-$(PROJECT).8: README.rst
+$(PROJECT).%: $(PROJECT).%.rst
 	rst2man.py $< > $@
 
+%.gz: %
+	gzip -c $< > $@
+
 clean:
-	rm -rf build/ dist/ *.egg-info
+	rm -rf build/ dist/ *.egg-info $(MANPAGES) $(patsubst %.gz, %, $(MANPAGES))
 
 test:
 	isort -df -vb -ns "__init__.py" -sg "" -s "" -rc -c -p $(PROJECT) $(PROJECT)

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,164 @@
+===========
+ backupctl
+===========
+
+Manage dirvish backups with an underlying zfs storage pool.
+
+
+SYNOPSIS
+=========
+
+``backupctl COMMAND [OPTIONS]``
+
+``backupctl log``
+
+``backupctl [--help]``
+
+
+DESCRIPTION
+============
+Tool to manage zfs volumes and create new dirvish vault configurations. This
+tool depends on a already present zfs pool, normally called backup.
+This tool (which is pronounced "backup cuddle") should be run with root
+privileges, if not possible, at least zfs fuse access as user is needed
+(to create new or remove existing zfs datasets and set quotas).
+This is more tricky and may not be tested as well as zfs with the kernel
+module.
+
+
+COMMANDS
+=========
+All subcommands that modify zfs volumes and dirvish configurations.
+
+new -n customer [-v server/vault] [-s size]
+--------------------------------------------
+Create a new customer zfs volume or a new dirvish vault inside a customer.
+
+resize -n customer [-v server/vault] -s size
+---------------------------------------------
+Resize an existing customer zfs volume or dirvish vault inside a customer.
+Shrinking is supported too.
+
+remove -n customer [-v server/vault]
+-------------------------------------
+Remove an existing customer zfs volume or dirvish vault inside a customer.
+If removing a customer, all dirvish vaults inside this customer will be removed
+too.
+
+log
+----
+Show the history of generating, resizing and removing customers and servers.
+
+
+OPTIONS
+========
+
+-v, --vault             Specify the hostname of the dirvish vault name.
+--dirvish-client        Specify a client ip or fqdn to back up. Needed if
+                        different from option client.
+-h, --help              Show this help message and exit.
+-n, --name              Customer name. Used as a logical group of dirvish
+                        vaults.
+-s, --size              Quota of a customer or a server. Size can be written
+                        human readable as MB, GB and so on.
+
+
+EXAMPLES
+=========
+
+CUSTOMER MANAGEMENT
+--------------------
+
+Create a new customer with a quota of 10G.
+
+  backupctl new -n customer1 -s 10G
+
+Resize the quota of an existing customer to 20G.
+
+  backupctl resize -n customer1 -s 20G
+
+Remove a customer with all his servers. All data will be lost.
+
+  backupctl remove -n customer1
+
+SERVER MANAGEMENT
+------------------
+
+Create a new server/vault www.example.com for customer1 with no special quota
+(it will inherit the quota of the customer).
+
+  backupctl new -n customer1 -v www.example.com
+
+Create a new server/vault www.example.com for customer1 with a quota of 10G.
+Data inside this server will also count on the customer level).
+
+  backupctl new -n customer1 -v www.example.com -s 10G
+
+Create a new server/vault www.example.com which isn't directly accessible, so a
+special dirvish client is needed, in this case the server is reachable with the
+ip address 192.0.2.100.
+
+  backupctl new -n customer1 -v www.example.com -s 10G --dirvish-client 192.0.2.100
+
+Resize the quota of the server/vault www.example.com of customer1 to the size
+of 20G.
+
+  backupctl resize -n customer1 -v www.example.com -s 20G
+
+Remove the server/vault www.example.com of customer1, this will delete all the
+backups and also the dirvish configuration for this server.
+
+  backupctl remove -n customer1 -v www.example.com
+
+
+EXIT STATUS
+============
+The following exit values are returned:
+
+0
+  Successful completion.
+
+1
+  An error occurred.
+
+
+2
+  No command was given.
+
+
+FILES
+======
+
+/etc/backupctl.ini
+  System-wide configuration file.
+
+~/.config/backupctl.ini
+  User specific configuration file. Will overwrite the configuration options of
+  the system-wide configuration file.
+
+$PWD/backupctl.ini
+  Local configuration file. Will overwrite the configuration options of any
+  previous configuration file.
+
+/var/lib/backupctl.db
+  backupctl history database. This is an sqlite3 database.
+
+
+SEE ALSO
+=========
+
+* `backupctl(8)`_, backupctl man page
+* `backupctl.ini(5)`_, backupctl configuration file
+
+
+Copyright
+==========
+Copyright 2018 Adfinis SyGroup AG License GPLv3+:
+GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+.. _backupctl(8): backupctl.8.rst
+.. _backupctl.ini(5): backupctl.ini.5.rst
+
+.. vim: set et ts=2 sw=2 :

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ FILES
 /etc/backupctl.ini
   System-wide configuration file.
 
-~/.config/backupctl.ini
+$XDG_CONFIG_HOME/backupctl.ini
   User specific configuration file. Will overwrite the configuration options of
   the system-wide configuration file.
 
@@ -140,7 +140,7 @@ $PWD/backupctl.ini
   Local configuration file. Will overwrite the configuration options of any
   previous configuration file.
 
-/var/lib/backupctl.db
+/var/lib/backupctl/backupctl.db
   backupctl history database. This is an sqlite3 database.
 
 

--- a/backupctl.8.rst
+++ b/backupctl.8.rst
@@ -9,7 +9,7 @@
 :Author:
     Written by Tobias Rueetschi, Adfinis SyGroup AG.
 :Date:
-    April 2018
+    May 2018
 :Copyright:
     Copyright 2018 Adfinis SyGroup AG License GPLv3+:
     GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
@@ -156,9 +156,13 @@ System-wide configuration file.
 
 ~/.config/backupctl.ini
 ------------------------
-User specific configuration file. Will only be read if system-wide
-configuration doesn't exist. If it doesn't exist it will be created with
-default values.
+User specific configuration file. Will overwrite the configuration options of
+the system-wide configuration file.
+
+$PWD/backupctl.ini
+------------------------
+Local configuration file. Will overwrite the configuration options of any
+previous configuration file.
 
 /var/lib/backupctl/backupctl.db
 --------------------------------
@@ -168,6 +172,7 @@ backupctl history database. This is an sqlite3 database.
 SEE ALSO
 =========
 
-``dirvish(8)``
+* ``backupctl.ini(5)``, backupctl configuration file
+* ``dirvish(8)``, dirvish backup utility
 
 .. vim: set et ts=2 sw=2 :

--- a/backupctl.8.rst
+++ b/backupctl.8.rst
@@ -37,10 +37,11 @@ DESCRIPTION
 ============
 Tool to manage zfs volumes and create new dirvish vault configurations. This
 tool depends on a already present zfs pool, normally called backup.
-This tool should be run with root privileges, if not possible, at least zfs
-fuse access as user is needed (to create new or remove existing zfs datasets
-and set quotas). This is more tricky and may not be tested as well as zfs with
-the kernel module.
+This tool (which is pronounced "backup cuddle") should be run with root
+privileges, if not possible, at least zfs fuse access as user is needed
+(to create new or remove existing zfs datasets and set quotas).
+This is more tricky and may not be tested as well as zfs with the kernel
+module.
 
 
 COMMANDS

--- a/backupctl.ini.5.rst
+++ b/backupctl.ini.5.rst
@@ -1,0 +1,110 @@
+===============
+ backupctl.ini
+===============
+
+------------------------------------------
+ Configuration file for **backupctl(8)**.
+------------------------------------------
+
+:Author:
+    Written by Tobias Rueetschi, Adfinis SyGroup AG.
+:Date:
+    May 2018
+:Copyright:
+    Copyright 2018 Adfinis SyGroup AG License GPLv3+:
+    GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+    This is free software: you are free to change and redistribute it.
+    There is NO WARRANTY, to the extent permitted by law.
+:Version:
+    1.0
+:Manual section:
+    5
+:Manual group:
+    File Formats
+
+
+DESCRIPTION
+============
+backupctl uses a configuration file at one of the three locations
+(priority decreasing):
+
+* $PWD/backupctl.ini
+* $XDG_CONFIG_HOME/backupctl.ini
+* /etc/backupctl.ini
+
+If an option is found in a higher priority configuration file, it will overwrite
+the option of any lower priority configuration file.
+
+
+PARAMETERS
+===========
+There are two types of sections in the backupctl configuration file(s): database
+and ZFS. ZFS defines the options regarding the ZFS setup and file system
+configuration of the system. Database is used for the database configuration of
+backupctl.
+
+
+[database] OPTIONS
+===================
+In the [database] section it's possible to configure backupctl which database it
+should use. At the moment there is just one option:
+
+path
+  File path for the sqlite3 database. The file will be created if it doesn't
+  exists. The default is \`/var/lib/backupctl.db'.
+
+
+[zfs] OPTIONS
+==============
+
+The [zfs] section is the place where it's possible to configure how the zfs is
+setup on the system and where the dirvish bank is.
+It consists of the following options:
+
+pool
+  The ZFS pool name which should be used for to create the file systems in it.
+  This pool must already exist and you can find the name of it with
+  \`zpool list'.
+
+root
+  The dirvish bank where the zfs file systems should be mounted to. This is an
+  absolute path on you system, most certainly \`/srv/backups' or something like
+  that.
+
+
+EXAMPLES
+=========
+An basic example of the configuration file is:
+
+.. code-block:: ini
+
+  [database]
+  path = /var/lib/backupctl.db
+
+  [zfs]
+  pool = backup
+  root = /srv/backup
+
+
+FILES
+======
+
+/etc/backupctl.ini
+-------------------
+System-wide configuration file.
+
+$XDG_CONFIG_HOME/backupctl.ini
+-------------------------------
+User specific configuration file. Will overwrite the configuration options of
+the system-wide configuration file.
+
+$PWD/backupctl.ini
+------------------------
+Local configuration file. Will overwrite the configuration options of any
+previous configuration file.
+
+
+SEE ALSO
+=========
+
+``backupctl(8)``

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ isort>=4.3.4
 pytest>=3.5.0
 pytest-cov>=2.5.1
 pytest-mock>=1.9.0
+Pygments>=2.2.0


### PR DESCRIPTION
Adding a new manpage for `backupctl.ini`. The readme was renamed to backupctl.8.rst and a new readme was provided (with most of the content of backupctl.8.rst with some changes to make it nicer on GitHub).