### PR TITLE
fix the path in the files section of the manpages

### DIFF
--- a/backupctl.8.rst
+++ b/backupctl.8.rst
@@ -154,13 +154,13 @@ FILES
 -------------------
 System-wide configuration file.
 
-~/.config/backupctl.ini
-------------------------
+$XDG_CONFIG_HOME/backupctl.ini
+-------------------------------
 User specific configuration file. Will overwrite the configuration options of
 the system-wide configuration file.
 
 $PWD/backupctl.ini
-------------------------
+-------------------
 Local configuration file. Will overwrite the configuration options of any
 previous configuration file.
 

--- a/backupctl.ini.5.rst
+++ b/backupctl.ini.5.rst
@@ -99,7 +99,7 @@ User specific configuration file. Will overwrite the configuration options of
 the system-wide configuration file.
 
 $PWD/backupctl.ini
-------------------------
+-------------------
 Local configuration file. Will overwrite the configuration options of any
 previous configuration file.
 


### PR DESCRIPTION
##### SUMMARY
This PR will change the manpage and fix the configuration file location. Before the location was absolute in the home, but the software uses the location given from `XDG_CONFIG_HOME`.

##### ISSUE TYPE
 - Docs Pull Request