### PR TITLE
move from xdg to pyxdg and set all python to python3

### DIFF
--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse
@@ -8,7 +8,7 @@ import os
 import sqlite3
 import sys
 
-import xdg
+from xdg import BaseDirectory
 
 from backupctl import dirvish, history, zfs
 
@@ -143,7 +143,7 @@ def config():
     """
     cfg = configparser.ConfigParser()
     cfg.read(os.path.join(os.sep, 'etc', 'backupctl.db'))
-    cfg.read(os.path.join(xdg.XDG_CONFIG_HOME, 'backupctl.ini'))
+    cfg.read(os.path.join(BaseDirectory.xdg_config_home, 'backupctl.ini'))
     cfg.read('backupctl.ini')
 
     if not cfg.has_section('database'):

--- a/backupctl/backupctl_test.py
+++ b/backupctl/backupctl_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 """Test for class backupctl"""

--- a/backupctl/dirvish.py
+++ b/backupctl/dirvish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import logging

--- a/backupctl/dirvish_test.py
+++ b/backupctl/dirvish_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 """Test for class dirvish"""

--- a/backupctl/history.py
+++ b/backupctl/history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import logging

--- a/backupctl/history_test.py
+++ b/backupctl/history_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 """Test for class history"""

--- a/backupctl/version.py
+++ b/backupctl/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Version."""

--- a/backupctl/version_test.py
+++ b/backupctl/version_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import pytest

--- a/backupctl/zfs.py
+++ b/backupctl/zfs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import logging

--- a/backupctl/zfs_test.py
+++ b/backupctl/zfs_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 """Test for class zfs"""

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description='Manage dirvish backups with an underlying zfs storage pool.',
     long_description=README_TEXT,
     install_requires=(
-        'xdg',
+        'pyxdg',
         'jinja2',
     ),
     keywords='dirvish, zfs',


### PR DESCRIPTION
##### SUMMARY
There is no package for xdg, but one for pyxdg in CentOS 7. So a change to pyxdg is reasonable.

##### ISSUE TYPE
 - Bugfix Pull Request