### PR TITLE
fix ending of the configuration file in /etc

### DIFF
--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -142,7 +142,7 @@ def config():
     :rtype: `configparser.ConfigParser`
     """
     cfg = configparser.ConfigParser()
-    cfg.read(os.path.join(os.sep, 'etc', 'backupctl.db'))
+    cfg.read(os.path.join(os.sep, 'etc', 'backupctl.ini'))
     cfg.read(os.path.join(BaseDirectory.xdg_config_home, 'backupctl.ini'))
     cfg.read('backupctl.ini')
 


### PR DESCRIPTION
##### SUMMARY
The configuration file in `/etc` is used with a wrong ending. It's specified that the configuration file name is `/etc/backupctl.db`, but it should be `/etc/backupctl.ini`.

##### ISSUE TYPE
 - Bugfix Pull Request