### PR TITLE
backupctl database

### DIFF
--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -73,6 +73,8 @@ def main():
     args = parser.parse_args()
 
     cfg = config()
+    if not os.path.exists(os.path.dirname(cfg['database'].get('path'))):
+        os.makedirs(os.path.dirname(cfg['database'].get('path')))
     try:
         hist = history.History(cfg['database'].get('path'))
     except sqlite3.OperationalError as e:

--- a/backupctl/backupctl_test.py
+++ b/backupctl/backupctl_test.py
@@ -9,15 +9,19 @@ import pytest
 
 from backupctl import backupctl, history
 
+BACKUPCTL_DB = os.path.join(
+    os.sep,
+    'tmp',
+    'backupctl',
+    'backupctl.db',
+)
+
 
 @pytest.fixture(autouse=True)
 def hist():
-    hist_obj = history.History(os.path.join(
-        os.sep,
-        'tmp',
-        'backupctl',
-        'backupctl.db',
-    ))
+    if not os.path.exists(os.path.dirname(BACKUPCTL_DB)):
+        os.makedirs(os.path.dirname(BACKUPCTL_DB))
+    hist_obj = history.History(BACKUPCTL_DB)
     return hist_obj
 
 

--- a/backupctl/history.py
+++ b/backupctl/history.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import os
 import sqlite3
 
 logger = logging.getLogger(__name__)
@@ -11,7 +10,8 @@ logger = logging.getLogger(__name__)
 class History:
     """Store and show history of commands done with the backupctl tool.
 
-    :ivar string dbpath: Path to the history database.
+    :ivar string dbpath: Path to the backupctl database. The directory must
+                         exist.
 
     :raises sqlite3.OperationalError: if couldn't open the database.
     """
@@ -21,9 +21,6 @@ class History:
         self._conn = None
 
         self._path = dbpath
-        dirpath = os.path.dirname(self._path)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
         self._conn = sqlite3.connect(self._path)
         logger.debug(
             "Opened database {0} successfully".format(self._path)

--- a/backupctl/history_test.py
+++ b/backupctl/history_test.py
@@ -9,15 +9,19 @@ import pytest
 
 from backupctl import history
 
+BACKUPCTL_DB = os.path.join(
+    os.sep,
+    'tmp',
+    'backupctl',
+    'backupctl.db',
+)
+
 
 @pytest.fixture(autouse=True)
 def hist():
-    hist_obj = history.History(os.path.join(
-        os.sep,
-        'tmp',
-        'backupctl',
-        'backupctl.db',
-    ))
+    if not os.path.exists(os.path.dirname(BACKUPCTL_DB)):
+        os.makedirs(os.path.dirname(BACKUPCTL_DB))
+    hist_obj = history.History(BACKUPCTL_DB)
     return hist_obj
 
 


### PR DESCRIPTION
##### SUMMARY
The database should be created before a history object is defined. The database will be later used on more places as only the history class.

##### ISSUE TYPE
 - Feature Pull Request