### PR TITLE
Object Relation Manager

### DIFF
--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -150,6 +150,8 @@ def config():
 
     if not cfg.has_section('database'):
         cfg.add_section('database')
+    if not cfg.has_option('database', 'type'):
+        cfg['database']['type'] = 'sqlite'
     if not cfg.has_option('database', 'path'):
         cfg['database']['path'] = os.path.join(
             os.sep,
@@ -157,6 +159,11 @@ def config():
             'lib',
             'backupctl',
             'backupctl.db',
+        )
+    if not cfg.has_option('database', 'fullpath'):
+        cfg['database']['fullpath'] = '{0}:///{1}'.format(
+            cfg['database'].get('type'),
+            cfg['database'].get('path'),
         )
     return cfg
 

--- a/backupctl/backupctl_test.py
+++ b/backupctl/backupctl_test.py
@@ -6,22 +6,24 @@
 import os
 
 import pytest
+import sqlalchemy
 
 from backupctl import backupctl, history
 
-BACKUPCTL_DB = 'sqlite:///{0}'.format(os.path.join(
+BACKUPCTL_DB = os.path.join(
     os.sep,
     'tmp',
     'backupctl',
     'backupctl.db',
-))
+)
 
 
 @pytest.fixture(autouse=True)
 def hist():
     if not os.path.exists(os.path.dirname(BACKUPCTL_DB)):
         os.makedirs(os.path.dirname(BACKUPCTL_DB))
-    hist_obj = history.History(BACKUPCTL_DB)
+    engine = sqlalchemy.create_engine('sqlite:///{0}'.format(BACKUPCTL_DB))
+    hist_obj = history.History(engine)
     return hist_obj
 
 

--- a/backupctl/backupctl_test.py
+++ b/backupctl/backupctl_test.py
@@ -9,12 +9,12 @@ import pytest
 
 from backupctl import backupctl, history
 
-BACKUPCTL_DB = os.path.join(
+BACKUPCTL_DB = 'sqlite:///{0}'.format(os.path.join(
     os.sep,
     'tmp',
     'backupctl',
     'backupctl.db',
-)
+))
 
 
 @pytest.fixture(autouse=True)
@@ -72,12 +72,14 @@ def test_main(parameters, exit_code, mocker, mock_zfs):
         import configparser
         cfg = configparser.ConfigParser()
         cfg['database'] = {
+            'type': 'sqlite',
             'path': os.path.join(
                 os.sep,
                 'tmp',
                 'backupctl',
                 'backupctl.db',
-            )
+            ),
+            'fullpath': 'sqlite:////tmp/backupctl/backupctl.db',
         }
         cfg['zfs'] = {
             'pool': 'backup',
@@ -86,7 +88,7 @@ def test_main(parameters, exit_code, mocker, mock_zfs):
                 'tmp',
                 'backupctl',
                 'backup',
-            )
+            ),
         }
         return cfg
 
@@ -101,7 +103,9 @@ def test_config():
     cfg = backupctl.config()
     import configparser
     assert type(cfg) == configparser.ConfigParser
+    assert type(cfg['database']['type']) == str
     assert type(cfg['database']['path']) == str
+    assert type(cfg['database']['fullpath']) == str
     assert type(cfg['zfs']['pool']) == str
     assert type(cfg['zfs']['root']) == str
 

--- a/backupctl/history_test.py
+++ b/backupctl/history_test.py
@@ -6,22 +6,24 @@
 import os
 
 import pytest
+import sqlalchemy
 
 from backupctl import history
 
-BACKUPCTL_DB = 'sqlite:///{0}'.format(os.path.join(
+BACKUPCTL_DB = os.path.join(
     os.sep,
     'tmp',
     'backupctl',
     'backupctl.db',
-))
+)
 
 
 @pytest.fixture(autouse=True)
 def hist():
     if not os.path.exists(os.path.dirname(BACKUPCTL_DB)):
         os.makedirs(os.path.dirname(BACKUPCTL_DB))
-    hist_obj = history.History(BACKUPCTL_DB)
+    engine = sqlalchemy.create_engine('sqlite:///{0}'.format(BACKUPCTL_DB))
+    hist_obj = history.History(engine)
     return hist_obj
 
 

--- a/backupctl/history_test.py
+++ b/backupctl/history_test.py
@@ -9,12 +9,12 @@ import pytest
 
 from backupctl import history
 
-BACKUPCTL_DB = os.path.join(
+BACKUPCTL_DB = 'sqlite:///{0}'.format(os.path.join(
     os.sep,
     'tmp',
     'backupctl',
     'backupctl.db',
-)
+))
 
 
 @pytest.fixture(autouse=True)

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     install_requires=(
         'pyxdg',
         'jinja2',
+        'SQLAlchemy',
     ),
     keywords='dirvish, zfs',
     url='https://www.adfinis-sygroup.ch/',


### PR DESCRIPTION
#### SUMMARY
Switch from plain SQLite3 to SQLAlchemy has multiple positive points, including:

- better maintainability
- support for more than just sqlite (like mysql and postgresql)
- smaller code
- no inline SQL

**This PR is following to PR #37 !**

#### ISSUE TYPE
 - Feature Pull Request

#### ADDITIONAL INFORMATION
This PR will break the actual backupctl database. The change must be made manual (there is no migration support by backupctl).
**Before**:
```
CREATE TABLE history
                (
                    id          INTEGER PRIMARY KEY AUTOINCREMENT   NOT NULL,
                    datetime    REAL                                NOT NULL,
                    command     TEXT                                NOT NULL,
                    customer    TEXT                                NOT NULL,
                    vault       TEXT,
                    size        TEXT
                );
```

**After**:
```
CREATE TABLE history (
        id INTEGER NOT NULL,
        datetime DATETIME,
        command VARCHAR,
        customer VARCHAR,
        vault VARCHAR,
        size VARCHAR,
        PRIMARY KEY (id)
);
```