### PR TITLE
allow to unset the quota.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Create a new customer zfs volume or a new dirvish vault inside a customer.
 resize -n customer [-v server/vault] -s size
 ---------------------------------------------
 Resize an existing customer zfs volume or dirvish vault inside a customer.
-Shrinking is supported too.
+Shrinking is supported too. To unset a quota, set the size to "none".
 
 remove -n customer [-v server/vault]
 -------------------------------------

--- a/backupctl.8.rst
+++ b/backupctl.8.rst
@@ -57,6 +57,7 @@ resize -n customer [-v server/vault] -s size
 Resize an existing customer zfs volume or dirvish vault inside a customer.
 Shrinking is supported too, but if there is more data in the vault than the
 size you're trying to shrink to an error will occur.
+To unset a quota, set the parameter size to "none".
 
 remove -n customer [-v server/vault]
 -------------------------------------

--- a/backupctl/zfs.py
+++ b/backupctl/zfs.py
@@ -65,13 +65,16 @@ def resize_filesystem(fs, size):
     :returns: True if the quota was set correctly, else False.
     :rtype: bool
     """
-    usage = filesystem_usage(fs)
-    if usage > parse_size(size):
-        logger.warn("new size ({0}) is smaller than used size ({1})".format(
-            size,
-            usage,
-        ))
-        return False
+    if size.lower() != 'none':
+        usage = filesystem_usage(fs)
+        if usage > parse_size(size):
+            logger.warn(
+                "new size ({0}) is smaller than used size ({1})".format(
+                    size,
+                    usage,
+                ),
+            )
+            return False
     returncode, stdout, stderr = execute_cmd([
         'zfs',
         'set',


### PR DESCRIPTION
##### SUMMARY
Unset a quota in zfs is done by "zfs set quota=none", this command will fail, because "none" can't be parsed as a float.

##### ISSUE TYPE
 - Bugfix


##### ZFS VERSION
```
filename:       /lib/modules/3.10.0-862.11.6.el7.x86_64/extra/zfs.ko.xz
version:        0.7.9-1
license:        CDDL
author:         OpenZFS on Linux
description:    ZFS
retpoline:      Y
rhelversion:    7.5
srcversion:     3ED35D12544F53FC04DF2C3
depends:        spl,znvpair,zcommon,zunicode,zavl,icp
vermagic:       3.10.0-862.11.6.el7.x86_64 SMP mod_unload modversions 
```