### PR TITLE
Fix travis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,6 @@ The following exit values are returned:
 1
   An error occurred.
 
-
 2
   No command was given.
 

--- a/backupctl.8.rst
+++ b/backupctl.8.rst
@@ -169,7 +169,6 @@ Successful completion.
 --
 An error occurred.
 
-
 2
 --
 No command was given.

--- a/backupctl/backupctl_test.py
+++ b/backupctl/backupctl_test.py
@@ -18,7 +18,7 @@ BACKUPCTL_DB = os.path.join(
 )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def ohistory():
     if not os.path.exists(os.path.dirname(BACKUPCTL_DB)):
         os.makedirs(os.path.dirname(BACKUPCTL_DB))
@@ -27,7 +27,7 @@ def ohistory():
     return hist_obj
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def odirvish():
     if not os.path.exists(os.path.dirname(BACKUPCTL_DB)):
         os.makedirs(os.path.dirname(BACKUPCTL_DB))
@@ -121,10 +121,10 @@ def test_config():
     assert type(cfg['zfs']['root']) == str
 
 
-def test_customer(mock_zfs):
+def test_customer(mock_zfs, ohistory, odirvish):
     backupctl.new(
-        ohistory(),
-        odirvish(),
+        ohistory,
+        odirvish,
         pool='backup',
         root=os.path.join(os.sep, 'tmp', 'backupctl', 'backup'),
         customer='customer1',
@@ -132,13 +132,13 @@ def test_customer(mock_zfs):
         client=None,
     )
     backupctl.resize(
-        ohistory(),
+        ohistory,
         pool='backup',
         customer='customer1',
         size='2G',
     )
     backupctl.remove(
-        ohistory(),
+        ohistory,
         pool='backup',
         customer='customer1',
     )
@@ -194,10 +194,10 @@ def test_customer(mock_zfs):
     ]
 
 
-def test_vault(mock_zfs):
+def test_vault(mock_zfs, ohistory, odirvish):
     backupctl.new(
-        ohistory(),
-        odirvish(),
+        ohistory,
+        odirvish,
         pool='backup',
         root=os.path.join(os.sep, 'tmp', 'backupctl', 'backup'),
         customer='customer1',
@@ -205,8 +205,8 @@ def test_vault(mock_zfs):
         client=None,
     )
     backupctl.new(
-        ohistory(),
-        odirvish(),
+        ohistory,
+        odirvish,
         pool='backup',
         root=os.path.join(os.sep, 'tmp', 'backupctl', 'backup'),
         customer='customer1',
@@ -215,8 +215,8 @@ def test_vault(mock_zfs):
         client=None,
     )
     backupctl.new(
-        ohistory(),
-        odirvish(),
+        ohistory,
+        odirvish,
         pool='backup',
         root=os.path.join(os.sep, 'tmp', 'backupctl', 'backup'),
         customer='customer1',
@@ -225,20 +225,20 @@ def test_vault(mock_zfs):
         client='192.0.2.1',
     )
     backupctl.resize(
-        ohistory(),
+        ohistory,
         pool='backup',
         customer='customer1',
         vault='mail.example.com',
         size='200M',
     )
     backupctl.remove(
-        ohistory(),
+        ohistory,
         pool='backup',
         customer='customer1',
         vault='mail.example.com',
     )
     backupctl.remove(
-        ohistory(),
+        ohistory,
         pool='backup',
         customer='customer1',
     )
@@ -348,10 +348,10 @@ def test_vault(mock_zfs):
 
 
 @pytest.mark.xfail
-def test_new_no_customer():
+def test_new_no_customer(ohistory, odirvish):
     backupctl.new(
-        ohistory(),
-        odirvish(),
+        ohistory,
+        odirvish,
         customer=None,
         vault=None,
         size=None,
@@ -360,10 +360,10 @@ def test_new_no_customer():
 
 
 @pytest.mark.xfail
-def test_new_no_vault_or_size():
+def test_new_no_vault_or_size(ohistory, odirvish):
     backupctl.new(
-        ohistory(),
-        odirvish(),
+        ohistory,
+        odirvish,
         customer='customer1',
         vault=None,
         size=None,
@@ -372,9 +372,9 @@ def test_new_no_vault_or_size():
 
 
 @pytest.mark.xfail
-def test_resize_no_customer():
+def test_resize_no_customer(ohistory):
     backupctl.resize(
-        ohistory(),
+        ohistory,
         customer=None,
         vault=None,
         size=None,
@@ -382,9 +382,9 @@ def test_resize_no_customer():
 
 
 @pytest.mark.xfail
-def test_resize_no_size():
+def test_resize_no_size(ohistory):
     backupctl.resize(
-        ohistory(),
+        ohistory,
         customer='customer1',
         vault=None,
         size=None,
@@ -392,13 +392,13 @@ def test_resize_no_size():
 
 
 @pytest.mark.xfail
-def test_remove_no_customer():
+def test_remove_no_customer(ohistory):
     backupctl.remove(
-        ohistory(),
+        ohistory,
         customer=None,
         vault=None,
     )
 
 
-def test_history_show():
-    backupctl.history_show(ohistory())
+def test_history_show(ohistory):
+    backupctl.history_show(ohistory)

--- a/backupctl/history_test.py
+++ b/backupctl/history_test.py
@@ -18,7 +18,7 @@ BACKUPCTL_DB = os.path.join(
 )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def hist():
     if not os.path.exists(os.path.dirname(BACKUPCTL_DB)):
         os.makedirs(os.path.dirname(BACKUPCTL_DB))
@@ -27,16 +27,16 @@ def hist():
     return hist_obj
 
 
-def test_add_customer():
-    assert hist().add(
+def test_add_customer(hist):
+    assert hist.add(
         customer='customer1',
         size='10G',
         command='test',
     )
 
 
-def test_add_vault():
-    assert hist().add(
+def test_add_vault(hist):
+    assert hist.add(
         customer='customer1',
         vault='www.example.com',
         size='10G',
@@ -44,24 +44,24 @@ def test_add_vault():
     )
 
 
-def test_show_one():
-    hist().add(
+def test_show_one(hist):
+    hist.add(
         customer='customer1',
         size='10G',
         command='test',
     )
-    hist().add(
+    hist.add(
         customer='customer2',
         size='20G',
         command='test',
     )
-    tdata = hist().show(
+    tdata = hist.show(
         count=1
     )
     assert type(tdata) == list
     assert len(tdata) == 1
 
 
-def test_show_default():
-    tdata = hist().show()
+def test_show_default(hist):
+    tdata = hist.show()
     assert type(tdata) == list


### PR DESCRIPTION
##### SUMMARY
Py.test 4.0 deprecated the calling fixtures directly, this caused trouble in the Travis CI.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ADDITIONAL INFORMATION
Fixture called directly. Fixtures are not meant to be called directly, but are created automatically when test functions request them as parameters.
See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code.
