### PR TITLE
WIP: support python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: python
 
-python:
-  - 3.4
-  - 3.5
-  - 3.6
+matrix:
+  include:
+    - name: "Python 3.7 on Linux Ubuntu Xenial"
+      python: 3.7
+      dist: xenial
+    - name: "Python 3.6 on Linux"
+      python: 3.6
+    - name: "Python 3.5 on Linux"
+      python: 3.5
+    - name: "Python 3.4 on Linux"
+      python: 3.4
 
 addons:
   apt:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
##### SUMMARY
Add Python 3.7 support.

##### ISSUE TYPE
 - Feature Pull Request

##### ADDITIONAL INFORMATION
At the moment Travis doesn't support Python 3.7 (except for the dev branch), this PR should be checked again when Python 3.7 is also available in Travis.