### PR TITLE
add common docker image paths to dirvish default excludes

### DIFF
--- a/backupctl/dirvish.py
+++ b/backupctl/dirvish.py
@@ -64,6 +64,19 @@ class Dirvish:
             '/var/cache/yum/*',
             'lost+found/',
             '*~',
+            '/var/lib/docker/aufs/*',
+            '/var/lib/docker/builder/*',
+            '/var/lib/docker/containers/*',
+            '/var/lib/docker/devicemapper/*',
+            '/var/lib/docker/image/*',
+            '/var/lib/docker/network/*',
+            '/var/lib/docker/overlay/*',
+            '/var/lib/docker/overlay2/*',
+            '/var/lib/docker/plugins/*',
+            '/var/lib/docker/repositories-aufs/*',
+            '/var/lib/docker/swarm/*',
+            '/var/lib/docker/tmp/*',
+            '/var/lib/docker/trust/*'
         ]
         self._engine = engine
         Base.metadata.create_all(engine)


### PR DESCRIPTION
##### SUMMARY
add common docker image paths to dirvish default excludes

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


