### PR TITLE
Fix customer creation

### DIFF
--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -251,7 +251,7 @@ def new(hist, dirvish, pool, root, customer, vault=None, size=None, client=None)
         path = os.path.join(root, customer, vault)
     else:
         fs = os.path.join(pool, customer)
-        path = os.path.join(root, customer)
+        path = None
     fs_status = zfs.new_filesystem(fs, path, size)
     if fs_status:
         hist.add(customer, "create", vault, size)

--- a/backupctl/backupctl_test.py
+++ b/backupctl/backupctl_test.py
@@ -115,7 +115,7 @@ def test_customer(mock_zfs, ohistory, odirvish):
         ohistory,
         odirvish,
         pool="backup",
-        root=os.path.join(os.sep, "tmp", "backupctl", "backup"),
+        root=None,
         customer="customer1",
         size="1G",
         client=None,
@@ -133,14 +133,11 @@ def test_customer(mock_zfs, ohistory, odirvish):
             "-o",
             "quota=1G",
             "-o",
-            "mountpoint={0}".format(
-                os.path.join(os.sep, "tmp", "backupctl", "backup", "customer1")
-            ),
+            "mountpoint=none"
             "backup/customer1",
         ],
         ["zfs", "get", "-H", "-o", "value", "-p", "used", "backup/customer1"],
         ["zfs", "set", "quota=2G", "backup/customer1"],
-        ["zfs", "set", "mountpoint=none", "backup/customer1"],
         ["zfs", "destroy", "-r", "-f", "backup/customer1"],
     ]
 

--- a/backupctl/backupctl_test.py
+++ b/backupctl/backupctl_test.py
@@ -133,11 +133,12 @@ def test_customer(mock_zfs, ohistory, odirvish):
             "-o",
             "quota=1G",
             "-o",
-            "mountpoint=none"
+            "mountpoint=none",
             "backup/customer1",
         ],
         ["zfs", "get", "-H", "-o", "value", "-p", "used", "backup/customer1"],
         ["zfs", "set", "quota=2G", "backup/customer1"],
+        ["zfs", "set", "mountpoint=none", "backup/customer1"],
         ["zfs", "destroy", "-r", "-f", "backup/customer1"],
     ]
 
@@ -194,9 +195,7 @@ def test_vault(mock_zfs, ohistory, odirvish):
             "-o",
             "quota=1G",
             "-o",
-            "mountpoint={0}".format(
-                os.path.join(os.sep, "tmp", "backupctl", "backup", "customer1")
-            ),
+            "mountpoint=none",
             "backup/customer1",
         ],
         [

--- a/backupctl/zfs.py
+++ b/backupctl/zfs.py
@@ -7,7 +7,7 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
-def new_filesystem(fs, path, size=None, compression=True):
+def new_filesystem(fs, path=None, size=None, compression=True):
     """Create a new zfs file system. The file system is automatically mounted
     according to the path property.
 
@@ -28,6 +28,8 @@ def new_filesystem(fs, path, size=None, compression=True):
         size = ["-o", "quota={0}".format(size)]
     else:
         size = []
+    if path is None:
+        path = "none"
 
     returncode, stdout, stderr = execute_cmd(
         ["zfs", "create", "-o", compression, "-o", "dedup=off"]


### PR DESCRIPTION
##### SUMMARY
Fixes mountpoints when creating customers. Customers do not need a mountpoint, as those are only used as logical groups to group vaults together.
The problem is the following:

group: backup/example
vault: backup/example/web-01.example.com

backup/example cannot be mounted by ZFS if the mountpoint isnt empty, which it obviously isnt, as it contains the mointpoint for
backup/example/web-01.example.com. The only option is to remove the unnecessary mountpoint for groups, as they are only used to logically groups vaults anyway.



##### ISSUE TYPE
 - Bugfix Pull Request



##### ZFS VERSION
<!--- Paste verbatim output from "modinfo zfs | grep -v ^parm" between quotes below -->
```
filename:       /lib/modules/3.10.0-1160.31.1.el7.x86_64/extra/zfs.ko.xz
version:        0.8.6-1
license:        CDDL
author:         OpenZFS on Linux
description:    ZFS
alias:          devname:zfs
alias:          char-major-10-249
retpoline:      Y
rhelversion:    7.9
srcversion:     991BB025BFBE22C3FF121F3
depends:        spl,znvpair,icp,zlua,zunicode,zcommon,zavl
vermagic:       3.10.0-1160.31.1.el7.x86_64 SMP mod_unload modversions 
```

