### PR TITLE
Remove directory after zfs destroy

### DIFF
--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -301,6 +301,7 @@ def remove(hist, pool, customer, vault=None):
     else:
         fs = os.path.join(pool, customer)
     zfs.remove_filesystem(fs)
+    os.rmdir(fs)
     hist.add(customer, "remove", vault)
 
 

--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -301,7 +301,8 @@ def remove(hist, pool, customer, vault=None):
     else:
         fs = os.path.join(pool, customer)
     zfs.remove_filesystem(fs)
-    os.rmdir(fs)
+    if os.path.isdir(fs):
+        os.rmdir(fs)
     hist.add(customer, "remove", vault)
 
 


### PR DESCRIPTION

##### SUMMARY
Delete the empty mountpoint after the vault has been removed.
Resolves https://github.com/adfinis-sygroup/backupctl/issues/50


##### ISSUE TYPE
- Feature Pull Request


##### TODO
- [x] Tests missing